### PR TITLE
chore: Adding prefixes to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: 'gomod'
+    directory: '/'
+    commit-message:
+      prefix: 'chore(dependabot-go): '
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    commit-message:
+      prefix: 'chore(dependabot-github-actions): '
+    schedule:
+      interval: 'weekly'
+  - package-ecosystem: 'docker'
+    directory: '/'
+    commit-message:
+      prefix: 'chore(dependabot-docker): '
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- We now have dependabot creating PR's with title that does not meet release-drafter requirements

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Dependabot config will add prefix to commits, which in turn adds prefix to PR title
- We have a prefix `chore(dependabot-go): ` for gomod updates
- We have a prefix `chore(dependabot-github-actions): ` for github actions updates
- We have a prefix `chore(dependabot-docker): ` for dockerfile updates

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
